### PR TITLE
document and expose the introJS options hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,75 @@ Called when the user finishes the intro by clicking "Done" or hitting
 right on the keyboard until the end. Called with the last step and the
 introJS component instance.
 
+## Intro JS Options
+
+Intro JS has a variety of options available to it. You can see the full
+list [here](https://github.com/usablica/intro.js#options), but we also
+provided the full list below. You'll notice that in the list below
+options all follow the dasherized convention of HTML and ember-cli
+filenames. The original list uses camelCase names, and so does IntroJS.
+Ember IntroJS will do the conversion for you.
+
+You can also set other options using the Handlebars helper syntax:
+`
+```handlebars
+{{intro-js steps=steps show-bullets=true}}
+```
+
+Or you could extend your own base class to override defaults
+instead of specifying them every time in the Handlebars helper:
+
+```javascript
+myapp/app/components/my-intro-js.js
+import IntroJSComponent from 'ember-introjs/components/intro-js';
+
+export default IntroJSComponent.extend({
+  'exit-on-esc': true
+});
+```
+
+You can also reopen the class:
+
+```javascript
+import IntroJSComponent from 'ember-introjs/components/intro-js';
+
+IntroJSComponent.reopen({
+  'exit-on-esc': true
+});
+```
+
+ - `steps`: For defining steps using JSON configuration (see
+   [this](https://github.com/usablica/intro.js/blob/master/example/programmatic/index.html)
+example)
+ - `next-label`: Next button label
+ - `prev-label`: Previous button label
+ - `skip-label`: Skip button label
+ - `done-label`: Done button label
+ - `tooltip-position`: Default tooltip position
+ - `tooltip-class`: Adding CSS class to all tooltips
+ - `highlight-class`: Additional CSS class for the helperLayer
+ - `exit-on-esc`: Exit introduction when pressing Escape button, `true` or
+   `false`
+ - `exit-on-overlay-click`: Exit introduction when clicking on overlay
+   layer, `true` or `false`
+ - `show-step-numbers`: Show steps number in the red circle or not, `true`
+   or `false`
+ - `keyboard-navigation`: Navigating with keyboard or not, `true` or
+   `false`
+ - `show-buttons`: Show introduction navigation buttons or not, `true` or
+   `false`
+ - `show-bullets`: Show introduction bullets or not, `true` or `false`
+ - `show-progress`: Show introduction progress or not, `true` or `false`
+ - `scroll-to-element`: Auto scroll to highlighted element if it's outside
+   of viewport, `true` or `false`
+ - `overlay-opacity`: Adjust the overlay opacity, `Number`
+ - `disable-interaction`: Disable an interaction inside element or not,
+   `true` or `false`
+
+See
+[setOption](https://github.com/usablica/intro.js/#introjssetoptionoption-value)
+to see an example.
+
 ### Testing Helpers
 
 Ember IntroJS comes with a set of testing helpers.

--- a/addon/components/intro-js.js
+++ b/addon/components/intro-js.js
@@ -2,20 +2,116 @@ import Ember from 'ember';
 
 var introJS = window.introJs;
 
+var INTRO_JS_OPTIONS = [
+  'next-label',
+  'prev-label',
+  'skip-label',
+  'done-label',
+  'tooltip-position',
+  'tooltip-class',
+  'highlightClass',
+  'exit-on-esc',
+  'exit-on-overlay-click',
+  'show-step-numbers',
+  'show-step-numbers',
+  'keyboard-navigation',
+  'show-buttons',
+  'show-bullets',
+  'show-progress',
+  'scroll-to-element',
+  'overlay-opacity',
+  'disable-interaction'
+];
+
 var IntroJSComponent = Ember.Component.extend({
 
   setupIntroJS: Ember.on('didInsertElement', function(){
     Ember.run.scheduleOnce('afterRender', this, this.startIntroJS);
   }),
 
+  /**
+   * Options passed to IntroJS. You can specify the options when using the
+   * Handlebars helper:
+   *
+   * ```handlebars
+   * {{intro-js steps=steps show-bullets=true}}
+   * ```
+   *
+   * Or you could extend your own base class to override defaults
+   * instead of specifying them every time in the Handlebars helper:
+   *
+   * ```javascript
+   * myapp/app/components/my-intro-js.js
+   *
+   * import IntroJSComponent from 'ember-introjs/components/intro-js';
+   *
+   * export default IntroJSComponent.extend({
+   *   'exit-on-esc': true
+   * });
+   * ```
+   *
+   * You can also reopen the class:
+   *
+   * ```javascript
+   * import IntroJSComponent from 'ember-introjs/components/intro-js';
+   *
+   * IntroJSComponent.reopen({
+   *   'exit-on-esc': true
+   * });
+   * ```
+   *
+   * @property
+  */
+  introJSOptions: Ember.computed(
+    'next-label',
+    'prev-label',
+    'skip-label',
+    'done-label',
+    'tooltip-position',
+    'tooltip-class',
+    'highlightClass',
+    'exit-on-esc',
+    'exit-on-overlay-click',
+    'show-step-numbers',
+    'show-step-numbers',
+    'keyboard-navigation',
+    'show-buttons',
+    'show-bullets',
+    'show-progress',
+    'scroll-to-element',
+    'overlay-opacity',
+    'disable-interaction',
+    'steps',
+
+    function(){
+      var camelize = Ember.String.camelize;
+      var underscore = Ember.String.underscore;
+
+      var options = {};
+
+      Ember.EnumerableUtils.forEach(INTRO_JS_OPTIONS, function(option){
+        var normalizedName = camelize(underscore(option));
+
+        var value = this.get(option);
+
+        if (value !== null && value !== undefined) {
+          options[normalizedName] = value;
+        }
+      }, this);
+
+      options.steps = this.get('steps');
+
+      return options;
+    }
+  ),
+
   startIntroJS: function(){
     if (this.get('start-if')){
       this._setIntroJS(introJS());
       var intro = this.get('introJS');
+      var options = this.get('introJSOptions');
 
-      intro.setOptions({
-        steps: this.get('steps')
-      });
+      intro.setOptions(options);
 
       this.registerCallbacksWithIntroJS();
       this._setCurrentStep(0);


### PR DESCRIPTION
This list of stuff for configuring introJS previously wasn't available. This lets you modify options like the position of the tooltip arrow and whatnot.