### PR TITLE
Fixed bower package name

### DIFF
--- a/blueprints/ember-introjs/index.js
+++ b/blueprints/ember-introjs/index.js
@@ -2,6 +2,6 @@ module.exports = {
   name: 'ember-introjs',
 
   afterInstall: function(options) {
-    return this.addBowerPackageToProject('introjs', '1.0.0');
+    return this.addBowerPackageToProject('intro.js', '1.0.0');
   }
 };


### PR DESCRIPTION
The bower component is actually instaelled to `bower_components/introjs/intro.js`, not `bower_components/intro.js/intro.js`.